### PR TITLE
reachability: set reachable property on main thread

### DIFF
--- a/MOLFCMClient.podspec
+++ b/MOLFCMClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'MOLFCMClient'
-  s.version      = '1.1'
+  s.version      = '1.2'
   s.platform     = :osx, '10.9'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.homepage     = 'https://github.com/google/macops-molfcmclient'


### PR DESCRIPTION
This will prevent multiple invocations of the reachability handler from different threads.