### PR TITLE
on disconnect remove the reference to _session

### DIFF
--- a/Source/MOLFCMClient/MOLFCMClient.h
+++ b/Source/MOLFCMClient/MOLFCMClient.h
@@ -98,7 +98,13 @@ typedef void (^MOLFCMAcknowledgeErrorHandler)(NSDictionary *, NSError *);
  */
 - (void)acknowledgeMessage:(NSDictionary *)message;
 
-/**  Closes all FCM connections. Stops Reachability. Outstanding tasks will be canceled. */
+/**
+ *  Closes all FCM connections. Stops Reachability. Outstanding tasks will be canceled.
+ *
+ *  @note After disconnect is called the receiver is considered dead. A new MOLFCMClient object
+ *        will need to be created to begin listening for messages.
+ *  @note After disconnect the receiver can hold a reference to itself for up to 15 minutes.
+ */
 - (void)disconnect;
 
 @end

--- a/Source/MOLFCMClient/MOLFCMClient.m
+++ b/Source/MOLFCMClient/MOLFCMClient.m
@@ -254,7 +254,8 @@ static void reachabilityHandler(SCNetworkReachabilityRef target, SCNetworkReacha
 
 - (void)disconnect {
   [self stopReachability];
-  [self cancelConnections];
+  [_session invalidateAndCancel];
+  _session = nil;
 }
 
 - (void)cancelConnections {

--- a/Source/MOLFCMClient/MOLFCMClient.m
+++ b/Source/MOLFCMClient/MOLFCMClient.m
@@ -254,7 +254,7 @@ static void reachabilityHandler(SCNetworkReachabilityRef target, SCNetworkReacha
 
 - (void)disconnect {
   [self stopReachability];
-  [_session invalidateAndCancel];
+  [self cancelConnections];
 }
 
 - (void)cancelConnections {


### PR DESCRIPTION
*  The backoff logic could try and use _session after `-[MOLFCMClient disconnect]` is called. Make _session nil to effectively make any backoff re-connection attempts become a no-op.

For completeness `dispatch_block_create` / `dispatch_block_cancel` were considered but were ruled out because MOLFCMClient supports clients back to 10.9.